### PR TITLE
Tab to indent/unindent

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -492,10 +492,53 @@ export function createTmTextarea(styles: Record<string, string>) {
               e.preventDefault()
               e.stopPropagation()
             }}
+            /* @ts-ignore */
+            on:keydown={e => {
+              const area = e.currentTarget
+              const value = area.value
 
+              if (e.key === 'Tab') {
+                e.preventDefault()
+
+                // fix me: it changes tabs for spaces
+                let { tabSize } = getComputedStyle(area)
+
+                let start = area.selectionStart
+                const end = area.selectionEnd
+
+                if (start !== end) {
+                  // something is selected
+                  // move "start" to previous `\n`
+                  while (start > 0 && value[start] !== '\n') {
+                    start--
+                  }
+
+                  let replacement
+
+                  if (e.shiftKey) {
+                    // unindent
+                    replacement = value
+                      .slice(start, end)
+                      .replace(new RegExp('\n' + ' '.repeat(+tabSize), 'g'), '\n')
+                  } else {
+                    // indent
+                    replacement = value
+                      .slice(start, end)
+                      .replace(/\n/g, '\n' + ' '.repeat(+tabSize))
+                  }
+                  area.setRangeText(replacement, start, end, 'select')
+                } else {
+                  area.setRangeText(' '.repeat(+tabSize), start, end, 'end')
+                }
+
+                // local
+                setSource(area.value)
+              }
+            }}
             /* @ts-ignore */
             on:input={e => {
               const target = e.currentTarget
+
               const value = target.value
 
               // local

--- a/src/index.module.css
+++ b/src/index.module.css
@@ -9,6 +9,7 @@
     background: var(--tm-background-color, inherit);
     overflow: auto;
     color: var(--tm-foreground-color, inherit);
+    tab-size: var(--tm-tab-size, 2);
   }
 }
 
@@ -22,6 +23,7 @@
   overflow: auto;
   color: var(--tm-foreground-color);
   font-size: 13px;
+  tab-size: var(--tm-tab-size, 2);
 
   & .code {
     display: block;
@@ -44,6 +46,7 @@
       & span {
         margin: 0px;
         background: transparent !important;
+        white-space: pre;
       }
     }
   }


### PR DESCRIPTION
Some experiment about using Tab to ident/unindent. For some reason cannot use the \t character, seems to be collapsed with other white spaces, even when using `white-space:pre`.
This allows 
- inserting \t (which is replaced by spaces btw)
- Select text and indent from the starting of the line for the current selection.
- Shift + \t with selected text to unindent from the starting of the line for the current selection.

There's a bug with the first line, I suppose the first line doesn't contain a \n