### PR TITLE
add `serializable: true` to `shadowOptions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "solid-js": "^1.6.0"
   },
   "dependencies": {
-    "@lume/element": "^0.12.0",
+    "@lume/element": "^0.13.1",
     "@solid-primitives/memo": "^1.3.9",
     "classy-solid": "^0.3.8",
     "clsx": "^2.1.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,7 @@ const TmTextareaStyleSheet = sheet(css)
 
 @element('tm-textarea')
 class TmTextareaElement extends Element {
-  shadowOptions = { mode: 'open' as const, serialize: true }
+  shadowOptions = { mode: 'open' as const, serializable: true }
 
   @booleanAttribute editable = true
   @stringAttribute grammar: Grammar = 'tsx'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,8 @@ const TmTextareaStyleSheet = sheet(css)
 
 @element('tm-textarea')
 class TmTextareaElement extends Element {
+  shadowOptions = { mode: 'open' as const, serialize: true }
+
   @booleanAttribute editable = true
   @stringAttribute grammar: Grammar = 'tsx'
   @stringAttribute stylesheet = ''


### PR DESCRIPTION
- add `serializable: true` to `shadowOptions` to allow `element.getHTML({serializableShadowRoots :true})` return the HTML of the content
- upgrade `@lume/element` which includes the new feature `shadowOptions`